### PR TITLE
MAKER-382 analogWrite breaks gpio/pwm functionality

### DIFF
--- a/hardware/intel/i686/cores/arduino/wiring_analog.c
+++ b/hardware/intel/i686/cores/arduino/wiring_analog.c
@@ -204,9 +204,9 @@ void analogWrite(uint32_t ulPin, uint32_t ulValue)
 		}
 		pin2alternate(&p);
 		
-		p->iHandle = sysfsGpioUnexport(p->ulGPIOId, p->sPath, sizeof(p->sPath));
+		//p->iHandle = sysfsGpioUnexport(p->ulGPIOId, p->sPath, sizeof(p->sPath));
 		digitalWrite(ulPin, 0);	//workaround since for tangier SoC bug when setting duty cycle to 0%
-		p->iHandle = sysfsGpioExport(p->ulGPIOId, p->sPath, sizeof(p->sPath));
+		//p->iHandle = sysfsGpioExport(p->ulGPIOId, p->sPath, sizeof(p->sPath));
 	}
 
 	


### PR DESCRIPTION
analogWrite breaks gpio/pwm functionality when setting the duty cycle to
0% after 916 calls of analogWrite(pin, 0)
