### PR TITLE
MAKER-340 Disabling trace breaks ADC functionality

### DIFF
--- a/hardware/intel/i686/cores/arduino/sysfs.c
+++ b/hardware/intel/i686/cores/arduino/sysfs.c
@@ -206,7 +206,7 @@ static int find_iio_dev_name(char *iio_dev_name, size_t iio_dev_name_len)
 			adc_dev_name[sizeof(LINUX_ADC_DEVICE_NAME)] = '\0';
 
 			if (!strncmp(adc_dev_name, LINUX_ADC_DEVICE_NAME,
-					sizeof(LINUX_ADC_DEVICE_NAME)))
+					(size_t)strlen(LINUX_ADC_DEVICE_NAME)))
 				break;
 		}
 		else {


### PR DESCRIPTION
Disabling trace with trace_enable(0) breaks ADC functionality.

When trace is disabled, there is garbage char at the end of buffer for
reading the adc device name. This causes the compare to fail and the adc
device is not found.
