### PR TITLE
Add String::c_str()

### DIFF
--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -160,6 +160,7 @@ public:
 	void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index=0) const;
 	void toCharArray(char *buf, unsigned int bufsize, unsigned int index=0) const
 		{getBytes((unsigned char *)buf, bufsize, index);}
+	const char * c_str() const { return buffer; }
 
 	// search
 	int indexOf( char ch ) const;


### PR DESCRIPTION
WString is out of sync with official Arduino implementation.
See the diff here: https://www.diffchecker.com/pzhscm6k
See also [issue #123 of ArduinoJson](https://github.com/bblanchon/ArduinoJson/issues/123)
