### PR TITLE
Unique library names for custom Edison libraries

### DIFF
--- a/libraries/DallasTemperature/library.properties
+++ b/libraries/DallasTemperature/library.properties
@@ -1,4 +1,4 @@
-name=DallasTemperature
+name=DallasTemperature(Edison)
 version=1.0
 author=*
 maintainer=*

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -1,4 +1,4 @@
-name=EEPROM
+name=EEPROM(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=Ethernet(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,4 +1,4 @@
-name=OneWire
+name=OneWire(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD
+name=SD(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -1,4 +1,4 @@
-name=SPI
+name=SPI(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Servo/keywords.txt
+++ b/libraries/Servo/keywords.txt
@@ -1,0 +1,24 @@
+#######################################
+# Syntax Coloring Map Servo
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+Servo	KEYWORD1	Servo
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+attach	KEYWORD2
+detach	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+attached	KEYWORD2
+writeMicroseconds	KEYWORD2
+readMicroseconds	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo
+name=Servo(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SoftwareServo/keywords.txt
+++ b/libraries/SoftwareServo/keywords.txt
@@ -1,0 +1,24 @@
+#######################################
+# Syntax Coloring Map Servo
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+SoftwareServo	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+attach	KEYWORD2
+detach	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+attached	KEYWORD2
+writeMicroseconds	KEYWORD2
+readMicroseconds	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/libraries/TimerOne/library.properties
+++ b/libraries/TimerOne/library.properties
@@ -1,4 +1,4 @@
-name=TimerOne
+name=TimerOne(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -1,4 +1,4 @@
-name=USBHost
+name=USBHost(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -1,4 +1,4 @@
-name=WiFi
+name=WiFi(Edison)
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -1,0 +1,30 @@
+#######################################
+# Syntax Coloring Map For Wire
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+begin	KEYWORD2
+setClock	KEYWORD2
+beginTransmission	KEYWORD2
+endTransmission	KEYWORD2
+requestFrom	KEYWORD2
+onReceive	KEYWORD2
+onRequest	KEYWORD2
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+Wire	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,4 +1,4 @@
-name=Wire
+name=Wire(Edison)
 version=1.0
 author=Intel
 maintainer=Intel


### PR DESCRIPTION
-Change names of custom libraries to prevent triggering of update prompt
for the library manager.
-Add keywords.txt to libraries that are missing them
