### PR TITLE
MAKER-413 Fix Edison missing first interrupt

### DIFF
--- a/cores/arduino/interrupt.c
+++ b/cores/arduino/interrupt.c
@@ -323,6 +323,7 @@ done:
 		sleep(10);
 		exit(ret);
 	}
+    delay(10);
 }
 
 /**


### PR DESCRIPTION
-added delay at the end of attachInterrupt()
