### PR TITLE
Update library naming and change architecture setting of EthernetShield

### DIFF
--- a/libraries/DallasTemperature/library.properties
+++ b/libraries/DallasTemperature/library.properties
@@ -1,4 +1,4 @@
-name=DallasTemperature(Edison)
+name=DallasTemperature
 version=1.0
 author=*
 maintainer=*

--- a/libraries/EEPROM/library.properties
+++ b/libraries/EEPROM/library.properties
@@ -1,4 +1,4 @@
-name=EEPROM(Edison)
+name=EEPROM
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Ethernet/library.properties
+++ b/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet(Edison)
+name=Ethernet
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/EthernetShield/library.properties
+++ b/libraries/EthernetShield/library.properties
@@ -1,11 +1,11 @@
-name=EthernetShield
+name=Ethernet
 author=Arduino
 email=info@arduino.cc
-sentence=The libary to use the Arduino Ethernet shield or the Arduino Ethernet based on the WizNet W5100.
+sentence=The library to use with the Arduino Ethernet shield or the Arduino Ethernet based on the WizNet W5100.
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
 category=Communication
 url=http://arduino.cc/en/Reference/Ethernet
-architectures=*
+architectures=i686
 version=1.0
 dependencies=SPI
 core-dependencies=arduino (>=1.5.0)

--- a/libraries/EthernetShield/library.properties
+++ b/libraries/EthernetShield/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet
+name=EthernetShield
 author=Arduino
 email=info@arduino.cc
 sentence=The library to use with the Arduino Ethernet shield or the Arduino Ethernet based on the WizNet W5100.

--- a/libraries/OneWire/library.properties
+++ b/libraries/OneWire/library.properties
@@ -1,4 +1,4 @@
-name=OneWire(Edison)
+name=OneWire
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SD/library.properties
+++ b/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD(Edison)
+name=SD
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/SPI/library.properties
+++ b/libraries/SPI/library.properties
@@ -1,4 +1,4 @@
-name=SPI(Edison)
+name=SPI
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Servo/library.properties
+++ b/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo(Edison)
+name=Servo
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/TimerOne/library.properties
+++ b/libraries/TimerOne/library.properties
@@ -1,4 +1,4 @@
-name=TimerOne(Edison)
+name=TimerOne
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/USBHost/library.properties
+++ b/libraries/USBHost/library.properties
@@ -1,4 +1,4 @@
-name=USBHost(Edison)
+name=USBHost
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/WiFi/library.properties
+++ b/libraries/WiFi/library.properties
@@ -1,4 +1,4 @@
-name=WiFi(Edison)
+name=WiFi
 version=1.0
 author=Intel
 maintainer=Intel

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,4 +1,4 @@
-name=Wire(Edison)
+name=Wire
 version=1.0
 author=Intel
 maintainer=Intel


### PR DESCRIPTION
Hi! We have a filtering system in place on the Arduino IDEs (and specifically on the Arduino Create IDE) based on the architecture, so there is no need to specify the board name in the library name :)

Also the EthernetShield had the wrong architecture tag.
@facchinm
